### PR TITLE
Field notes design amends

### DIFF
--- a/portal/src/App.vue
+++ b/portal/src/App.vue
@@ -31,6 +31,7 @@ body,
 #app {
     display: flex;
     flex-direction: column;
+    height: 100vh;
 }
 body {
     font-family: "Avenir", Helvetica, Arial, sans-serif;

--- a/portal/src/App.vue
+++ b/portal/src/App.vue
@@ -31,7 +31,7 @@ body,
 #app {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    min-height: 100vh;
 }
 body {
     font-family: "Avenir", Helvetica, Arial, sans-serif;

--- a/portal/src/assets/icon-chevron-right.svg
+++ b/portal/src/assets/icon-chevron-right.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="10px" height="18px" viewBox="0 0 10 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
+    <title>Icon_Cheveron_Right</title>
+    <desc>Created with Sketch.</desc>
+    <g id="UI_Stations" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="05_UI_Mobile_Stations" transform="translate(-312.000000, -368.000000)" stroke="#2C3E50" stroke-width="2">
+            <polyline id="Icon_Cheveron_Right" transform="translate(317.000000, 377.000000) rotate(-90.000000) translate(-317.000000, -377.000000) " points="309 373 317 381 325 373"></polyline>
+        </g>
+    </g>
+</svg>

--- a/portal/src/assets/icon-close-white.svg
+++ b/portal/src/assets/icon-close-white.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.1 (78136) - https://sketchapp.com -->
+    <title>Icon_Close</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="05.1_Mobile_FieldKitStation_Edit" transform="translate(-12.000000, -17.000000)" stroke="#fff" stroke-width="2">
+            <g id="Icon_Close" transform="translate(20.435029, 25.435029) rotate(45.000000) translate(-20.435029, -25.435029) translate(10.935029, 15.935029)">
+                <path d="M9.5,0 L9.5,19" id="Path-3"></path>
+                <path d="M9.5,0 L9.5,19" id="Path-3" transform="translate(9.500000, 9.500000) rotate(90.000000) translate(-9.500000, -9.500000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/portal/src/assets/icon-close.svg
+++ b/portal/src/assets/icon-close.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="17px" height="17px" viewBox="0 0 17 17" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.1 (78136) - https://sketchapp.com -->
+    <title>Icon_Close</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="05.1_Mobile_FieldKitStation_Edit" transform="translate(-12.000000, -17.000000)" stroke="#2C3E50" stroke-width="2">
+            <g id="Icon_Close" transform="translate(20.435029, 25.435029) rotate(45.000000) translate(-20.435029, -25.435029) translate(10.935029, 15.935029)">
+                <path d="M9.5,0 L9.5,19" id="Path-3"></path>
+                <path d="M9.5,0 L9.5,19" id="Path-3" transform="translate(9.500000, 9.500000) rotate(90.000000) translate(-9.500000, -9.500000) "></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/portal/src/assets/icon-tick.svg
+++ b/portal/src/assets/icon-tick.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="8" viewBox="0 0 10 8">
+    <defs>
+        <path id="oof8h3xzaa" d="M9 14.71c-.369.387-.966.387-1.333 0l-2.391-2.513c-.368-.388-.368-1.015 0-1.403.368-.386.965-.386 1.333 0l1.724 1.813 5.057-5.316c.368-.388.965-.388 1.334 0 .368.386.368 1.014 0 1.401L9 14.71z"/>
+    </defs>
+    <g fill="none" fill-rule="evenodd" transform="translate(-5 -7)">
+        <use fill="#2C3E50" xlink:href="#oof8h3xzaa"/>
+    </g>
+</svg>

--- a/portal/src/scss/_forms.scss
+++ b/portal/src/scss/_forms.scss
@@ -137,6 +137,23 @@
     }
 }
 
+.form {
+    &-edit {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid #d8dce0;
+        background: white;
+        padding: 0 22px 14px;
+        max-width: 700px;
+        position: relative;
+        text-align: left;
+
+        @include bp-down($xs) {
+            padding: 0 10px 14px;
+        }
+    }
+}
+
 .bold {
     font-weight: bold;
 }

--- a/portal/src/scss/_forms.scss
+++ b/portal/src/scss/_forms.scss
@@ -139,17 +139,24 @@
 
 .form {
     &-edit {
+        box-sizing: border-box;
         display: flex;
         flex-direction: column;
         border: 1px solid #d8dce0;
         background: white;
         padding: 0 22px 14px;
-        max-width: 700px;
+        width: 700px;
+        max-width: 100%;
         position: relative;
         text-align: left;
 
+        @include bp-down($md) {
+            max-width: 500px;
+        }
+
         @include bp-down($xs) {
-            padding: 0 10px 14px;
+            padding: 0 20px 14px;
+            width: 100%;
         }
     }
 }

--- a/portal/src/scss/_layout.scss
+++ b/portal/src/scss/_layout.scss
@@ -1,0 +1,21 @@
+.main-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background-color: #fcfcfc;
+    text-align: left;
+    padding: 65px 87px 60px;
+
+    @include bp-down($lg) {
+        padding: 45px 45px 60px;
+        align-items: center;
+    }
+
+    @include bp-down($sm) {
+        padding: 45px 20px 30px;
+    }
+
+    @include bp-down($xs) {
+        padding: 0;
+    }
+}

--- a/portal/src/scss/_layout.scss
+++ b/portal/src/scss/_layout.scss
@@ -1,3 +1,5 @@
+@import "mixins";
+
 .main-panel {
     display: flex;
     flex-direction: column;
@@ -17,5 +19,28 @@
 
     @include bp-down($xs) {
         padding: 0;
+    }
+}
+
+.container-wrap {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    max-width: 1080px;
+    background-color: #fcfcfc;
+    text-align: left;
+    padding: 40px 90px;
+
+    @include bp-down($lg) {
+        padding: 40px 60px;
+    }
+
+    @include bp-down($md) {
+        padding: 30px 30px;
+        max-width: 600px;
+    }
+
+    @include bp-down($xs) {
+        padding: 20px 10px;
     }
 }

--- a/portal/src/scss/_variables.scss
+++ b/portal/src/scss/_variables.scss
@@ -1,4 +1,5 @@
 $z-index-top: 1;
+$z-index-menu: 1000;
 
 $xs: 500;
 $sm: 768;

--- a/portal/src/scss/global.scss
+++ b/portal/src/scss/global.scss
@@ -1,0 +1,11 @@
+.button-solid {
+    width: 240px;
+    height: 45px;
+    color: white;
+    font-size: 18px;
+    font-weight: bold;
+    background-color: #ce596b;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}

--- a/portal/src/views/StandardLayout.vue
+++ b/portal/src/views/StandardLayout.vue
@@ -105,7 +105,7 @@ export default Vue.extend({
 .container-top {
     display: flex;
     flex-direction: row;
-    height: 100%;
+    height: 100vh;
 }
 .container-main {
     flex-grow: 1;

--- a/portal/src/views/auth/ChangePasswordForm.vue
+++ b/portal/src/views/auth/ChangePasswordForm.vue
@@ -1,34 +1,32 @@
 <template>
-    <div class="password-change">
-        <form @submit.prevent="saveForm">
-            <h3>Change Password</h3>
-            <div>
-                <TextField v-model="form.existing" label="Current password" type="password" />
+    <form @submit.prevent="saveForm">
+        <h3>Change Password</h3>
+        <div>
+            <TextField v-model="form.existing" label="Current password" type="password" />
 
-                <div class="validation-errors" v-if="$v.form.existing.$error">
-                    <div v-if="!$v.form.existing.required">This is a required field.</div>
-                    <div v-if="!$v.form.existing.min">Password must be at least 10 characters.</div>
-                </div>
+            <div class="validation-errors" v-if="$v.form.existing.$error">
+                <div v-if="!$v.form.existing.required">This is a required field.</div>
+                <div v-if="!$v.form.existing.min">Password must be at least 10 characters.</div>
             </div>
-            <div>
-                <TextField v-model="form.password" label="New password" type="password" />
+        </div>
+        <div>
+            <TextField v-model="form.password" label="New password" type="password" />
 
-                <div class="validation-errors" v-if="$v.form.password.$error">
-                    <div v-if="!$v.form.password.required">This is a required field.</div>
-                    <div v-if="!$v.form.password.min">Password must be at least 10 characters.</div>
-                </div>
+            <div class="validation-errors" v-if="$v.form.password.$error">
+                <div v-if="!$v.form.password.required">This is a required field.</div>
+                <div v-if="!$v.form.password.min">Password must be at least 10 characters.</div>
             </div>
-            <div>
-                <TextField v-model="form.passwordConfirmation" label="Confirm new password" type="password" />
+        </div>
+        <div>
+            <TextField v-model="form.passwordConfirmation" label="Confirm new password" type="password" />
 
-                <div class="validation-errors" v-if="$v.form.passwordConfirmation.$error">
-                    <div v-if="!$v.form.passwordConfirmation.required">Confirmation is a required field.</div>
-                    <div v-if="!$v.form.passwordConfirmation.sameAsPassword">Passwords must match.</div>
-                </div>
+            <div class="validation-errors" v-if="$v.form.passwordConfirmation.$error">
+                <div v-if="!$v.form.passwordConfirmation.required">Confirmation is a required field.</div>
+                <div v-if="!$v.form.passwordConfirmation.sameAsPassword">Passwords must match.</div>
             </div>
-            <button class="save" type="submit">Change password</button>
-        </form>
-    </div>
+        </div>
+        <button class="save" type="submit">Change password</button>
+    </form>
 </template>
 
 <script lang="ts">
@@ -115,11 +113,10 @@ export default Vue.extend({
 form > div {
     margin-bottom: 20px;
 }
-.password-change {
-    margin-top: 20px;
-}
+
 button.save {
     margin-top: 20px;
+    margin-bottom: 20px;
     width: 300px;
     height: 50px;
     color: white;
@@ -143,4 +140,9 @@ button.save {
     border: 2px;
     border-radius: 4px;
 }
+
+form {
+    margin-top: 60px;
+}
+
 </style>

--- a/portal/src/views/auth/ChangePasswordForm.vue
+++ b/portal/src/views/auth/ChangePasswordForm.vue
@@ -25,7 +25,7 @@
                 <div v-if="!$v.form.passwordConfirmation.sameAsPassword">Passwords must match.</div>
             </div>
         </div>
-        <button class="save" type="submit">Change password</button>
+        <button class="button-solid" type="submit">Change password</button>
     </form>
 </template>
 
@@ -83,7 +83,10 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/global';
+@import '../../scss/mixins';
+
 .main-panel {
     display: flex;
     flex-direction: column;
@@ -114,19 +117,6 @@ form > div {
     margin-bottom: 20px;
 }
 
-button.save {
-    margin-top: 20px;
-    margin-bottom: 20px;
-    width: 300px;
-    height: 50px;
-    color: white;
-    font-size: 18px;
-    font-weight: bold;
-    background-color: #ce596b;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-}
 .validation-errors {
     color: #c42c44;
     display: block;
@@ -143,6 +133,16 @@ button.save {
 
 form {
     margin-top: 60px;
+}
+
+.button-solid {
+    width: 335px;
+    margin-top: 15px;
+    margin-bottom: 20px;
+
+    @include bp-down($xs) {
+        width: 100%;
+    }
 }
 
 </style>

--- a/portal/src/views/auth/ProfileForm.vue
+++ b/portal/src/views/auth/ProfileForm.vue
@@ -34,7 +34,7 @@
                     <div v-if="!$v.form.bio.required">Short Description is a required field.</div>
                 </div>
             </div>
-            <button class="save" type="submit">Update</button>
+            <button class="button-solid" type="submit">Update</button>
         </form>
     </div>
 </template>
@@ -135,6 +135,7 @@ export default Vue.extend({
 <style scoped lang="scss">
 @import '../../scss/mixins';
 @import '../../scss/forms';
+@import '../../scss/global';
 
 h3 {
     font-size: 16px;
@@ -176,18 +177,12 @@ form > div {
     font-weight: 500;
     margin-bottom: 40px;
 }
-
-button.save {
+.button-solid {
     margin-top: 20px;
-    width: 240px;
-    height: 45px;
-    color: white;
-    font-size: 18px;
-    font-weight: bold;
-    background-color: #ce596b;
-    border: none;
-    border-radius: 3px;
-    cursor: pointer;
+
+    @include bp-down($xs) {
+        width: 100%;
+    }
 }
 .validation-errors {
     color: #c42c44;

--- a/portal/src/views/auth/ProfileForm.vue
+++ b/portal/src/views/auth/ProfileForm.vue
@@ -6,7 +6,6 @@
                 <ImageUploader :image="{ url: null }" v-if="!user.photo" @change="onImage" />
                 <ImageUploader :image="{ url: user.photo.url }" v-if="user.photo" @change="onImage" />
             </div>
-            <h3>User Profile</h3>
             <div>
                 <TextField v-model="form.name" label="Name" />
 
@@ -29,10 +28,10 @@
                 </div>
             </div>
             <div>
-                <TextField v-model="form.bio" label="Bio" />
+                <TextField v-model="form.bio" label="Short Description" />
 
                 <div class="validation-errors" v-if="$v.form.name.$error">
-                    <div v-if="!$v.form.bio.required">Bio is a required field.</div>
+                    <div v-if="!$v.form.bio.required">Short Description is a required field.</div>
                 </div>
             </div>
             <button class="save" type="submit">Update</button>
@@ -133,23 +132,22 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
-.main-panel {
-    display: flex;
-    flex-direction: column;
-    max-width: 700px;
-    padding: 20px;
+<style scoped lang="scss">
+@import '../../scss/mixins';
+@import '../../scss/forms';
+
+h3 {
+    font-size: 16px;
+    font-weight: 500;
+    margin-bottom: 8px;
 }
-.heading {
-    font-weight: bold;
-    font-size: 24px;
-}
+
 .image-container {
     margin-bottom: 40px;
 }
-/deep/ .user-image img {
-    max-width: 400px;
-    max-height: 400px;
+::v-deep .user-image img {
+    max-width: 198px!important;
+    max-height: 198px!important;
 }
 #loading {
     width: 100%;
@@ -178,19 +176,17 @@ form > div {
     font-weight: 500;
     margin-bottom: 40px;
 }
-.password-change {
-    margin-top: 20px;
-}
+
 button.save {
     margin-top: 20px;
-    width: 300px;
-    height: 50px;
+    width: 240px;
+    height: 45px;
     color: white;
     font-size: 18px;
     font-weight: bold;
     background-color: #ce596b;
     border: none;
-    border-radius: 5px;
+    border-radius: 3px;
     cursor: pointer;
 }
 .validation-errors {

--- a/portal/src/views/auth/UserView.vue
+++ b/portal/src/views/auth/UserView.vue
@@ -1,22 +1,26 @@
 <template>
     <StandardLayout>
-        <div class="user-view" v-if="user">
-            <div class="container">
-                <div class="heading">My Account</div>
-                <div class="notification success" v-if="notifySaved">
-                    Profile saved.
-                </div>
+        <div class="main-panel">
+            <div class="form-edit" v-if="user">
+                <div class="container">
+                    <div>
+                        <h2> My Account </h2>
+                    </div>
+                    <div class="notification success" v-if="notifySaved">
+                        Profile saved.
+                    </div>
 
-                <ProfileForm :user="user" @save="saveForm" />
+                    <ProfileForm :user="user" @save="saveForm" />
 
-                <div class="notification success" v-if="notifyPasswordChanged">
-                    Password changed.
-                </div>
-                <div class="notification failed" v-if="!passwordOk">
-                    Please check your password and try again.
-                </div>
+                    <div class="notification success" v-if="notifyPasswordChanged">
+                        Password changed.
+                    </div>
+                    <div class="notification failed" v-if="!passwordOk">
+                        Please check your password and try again.
+                    </div>
 
-                <ChangePasswordForm :user="user" @save="changePassword" />
+                    <ChangePasswordForm :user="user" @save="changePassword" />
+                </div>
             </div>
         </div>
     </StandardLayout>
@@ -114,15 +118,11 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
-.user-view {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    background-color: #fcfcfc;
-    padding: 40px;
-    text-align: left;
-}
+<style scoped lang="scss">
+@import '../../scss/mixins';
+@import '../../scss/forms';
+@import '../../scss/layout';
+
 .container {
     max-width: 700px;
 }
@@ -133,7 +133,7 @@ export default Vue.extend({
 .image-container {
     margin-bottom: 40px;
 }
-/deep/ .user-image img {
+::v-deep .user-image img {
     max-width: 400px;
     max-height: 400px;
 }

--- a/portal/src/views/auth/UserView.vue
+++ b/portal/src/views/auth/UserView.vue
@@ -2,25 +2,21 @@
     <StandardLayout>
         <div class="main-panel">
             <div class="form-edit" v-if="user">
-                <div class="container">
-                    <div>
-                        <h2> My Account </h2>
-                    </div>
-                    <div class="notification success" v-if="notifySaved">
-                        Profile saved.
-                    </div>
-
-                    <ProfileForm :user="user" @save="saveForm" />
-
-                    <div class="notification success" v-if="notifyPasswordChanged">
-                        Password changed.
-                    </div>
-                    <div class="notification failed" v-if="!passwordOk">
-                        Please check your password and try again.
-                    </div>
-
-                    <ChangePasswordForm :user="user" @save="changePassword" />
+                <h2> My Account </h2>
+                <div class="notification success" v-if="notifySaved">
+                    Profile saved.
                 </div>
+
+                <ProfileForm :user="user" @save="saveForm" />
+
+                <div class="notification success" v-if="notifyPasswordChanged">
+                    Password changed.
+                </div>
+                <div class="notification failed" v-if="!passwordOk">
+                    Please check your password and try again.
+                </div>
+
+                <ChangePasswordForm :user="user" @save="changePassword" />
             </div>
         </div>
     </StandardLayout>
@@ -123,9 +119,6 @@ export default Vue.extend({
 @import '../../scss/forms';
 @import '../../scss/layout';
 
-.container {
-    max-width: 700px;
-}
 .heading {
     font-weight: bold;
     font-size: 24px;
@@ -164,17 +157,7 @@ export default Vue.extend({
 .password-change {
     margin-top: 20px;
 }
-.save-btn {
-    width: 300px;
-    height: 50px;
-    color: white;
-    font-size: 18px;
-    font-weight: bold;
-    background-color: #ce596b;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-}
+
 .validation-errors {
     color: #c42c44;
     display: block;

--- a/portal/src/views/notes/NoteEditor.vue
+++ b/portal/src/views/notes/NoteEditor.vue
@@ -60,6 +60,7 @@ export default Vue.extend({
 
 <style scoped>
 .note-editor {
+
 }
 
 .title {

--- a/portal/src/views/notes/NotesForm.vue
+++ b/portal/src/views/notes/NotesForm.vue
@@ -113,11 +113,19 @@ export default Vue.extend({
     display: flex;
     flex-direction: column;
     padding: 28px;
+
+    @include bp-down($md) {
+        padding: 28px 0;
+    }
 }
 .header {
     @include flex(center);
     padding-bottom: 11px;
     border-bottom: 1px solid #d8dce0;
+
+    @include bp-down($md) {
+        border: 0;
+    }
 }
 .header .name {
     color: #2c3e50;

--- a/portal/src/views/notes/NotesForm.vue
+++ b/portal/src/views/notes/NotesForm.vue
@@ -5,7 +5,7 @@
                 <div class="name">{{ station.name }}</div>
                 <div class="completed">{{ completed }}% Complete</div>
                 <div class="buttons">
-                    <div class="button" v-on:click="onSave">Save</div>
+                    <button type="submit" class="button" v-on:click="onSave">Save</button>
                 </div>
             </div>
             <div class="site-notes">
@@ -105,17 +105,18 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/mixins';
+
 .notes-form {
     text-align: left;
     display: flex;
     flex-direction: column;
-    padding: 20px;
+    padding: 28px;
 }
 .header {
-    display: flex;
-    align-items: baseline;
-    padding-bottom: 25px;
+    @include flex(center);
+    padding-bottom: 11px;
     border-bottom: 1px solid #d8dce0;
 }
 .header .name {
@@ -137,13 +138,19 @@ export default Vue.extend({
     margin-top: 20px;
 }
 .button {
-    margin-left: 20px;
-    font-size: 12px;
-    padding: 5px 10px;
+    padding: 0;
+    width: 80px;
+    height: 33px;
+    border-radius: 3px;
+    border: solid 1px #cccdcf;
     background-color: #ffffff;
-    border: 1px solid rgb(215, 220, 225);
-    border-radius: 4px;
-    cursor: pointer;
+    font-size: 14px;
+    font-weight: 900;
+    letter-spacing: 0.08px;
+    color: #2c3e50;
+    margin-left: 7px;
+    margin-bottom: 0;
+    @include flex(center, center);
 }
 
 .photos {
@@ -155,7 +162,7 @@ export default Vue.extend({
     flex-basis: 400px;
 }
 
-/deep/ .photos img {
+::v-deep .photos img {
     max-width: 400px;
     max-height: 400px;
     margin-right: 10px;

--- a/portal/src/views/notes/NotesForm.vue
+++ b/portal/src/views/notes/NotesForm.vue
@@ -115,7 +115,7 @@ export default Vue.extend({
     padding: 28px;
 
     @include bp-down($md) {
-        padding: 28px 0;
+        padding: 25px 8px;
     }
 }
 .header {
@@ -125,6 +125,7 @@ export default Vue.extend({
 
     @include bp-down($md) {
         border: 0;
+        padding: 0;
     }
 }
 .header .name {

--- a/portal/src/views/notes/NotesView.vue
+++ b/portal/src/views/notes/NotesView.vue
@@ -11,15 +11,15 @@
                 <template v-else>
                     <div class="station-tabs">
                         <div class="tab"
-                            v-for="station in stations"
-                            v-bind:key="station.id"
-                            v-on:click="(ev) => onSelected(ev, station)">
-
-                            <div class="name">
-                                {{ station.name }}
+                             v-for="station in stations"
+                             v-bind:key="station.id"
+                             v-bind:class="{active: selectedStation.id === station.id}"
+                             v-on:click="onSelected(station)">
+                            <div class="tab-wrap">
+                                <div class="name"> {{ station.name }} </div>
+                                <div v-if="station.deployedAt" class="deployed">Deployed</div>
+                                <div v-else class="undeployed">Not Deployed</div>
                             </div>
-                            <div v-if="station.deployedAt" class="deployed">Deployed</div>
-                            <div v-else class="undeployed">Not Deployed</div>
                             <div class="tab-content" v-if="selectedStation && selectedNotes">
                                 <div class="notifications">
                                     <div v-if="failed" class="notification failed">
@@ -45,37 +45,11 @@
                                         @change="onChange"
                                 />
                             </div>
-                        </div>
-                    </div>
-                    <!--<div class="main" v-if="selectedStation && selectedNotes">
-                        <div class="notifications">
-                            <div v-if="failed" class="notification failed">
-                                Oops, there was a problem.
-                            </div>
-
-                            <div v-if="success" class="notification success">
-                                Saved.
+                            <div v-else class="main empty">
+                                Please choose a station from the left.
                             </div>
                         </div>
-                        <NotesViewer
-                                :station="selectedStation"
-                                :notes="selectedNotes"
-                                v-bind:key="stationId"
-                                v-if="project.project.readOnly"
-                        />
-                        <NotesForm
-                                v-else
-                                :station="selectedStation"
-                                :notes="selectedNotes"
-                                @save="saveForm"
-                                v-bind:key="stationId"
-                                @change="onChange"
-                        />
                     </div>
-
-                    <div class="side">
-                        <StationTabs :stations="visibleStations" :selected="selectedStation" @selected="onSelected" />
-                    </div>-->
                     <template v-if="loading">
                         <div class="main">
                             <Spinner />
@@ -248,8 +222,8 @@ export default Vue.extend({
                 Vue.set(this, "loading", false);
             });
         },
-        onSelected(this: any, station) {
-            console.log("on selected", this, station);
+        onSelected(station) {
+            console.log("on selected", station);
             if (this.stationId != station.id) {
                 return this.$router.push({
                     name: this.projectId ? "viewProjectStationNotes" : "viewStationNotes",
@@ -308,7 +282,6 @@ export default Vue.extend({
 .notes-view .lower {
     display: flex;
     flex-direction: row;
-    border: 1px solid #d8dce0;
     background: white;
     margin-top: 20px;
     position: relative;
@@ -327,7 +300,7 @@ export default Vue.extend({
 
 .notification.success {
     margin-top: 20px;
-    margin-bottom: 20px;
+    margin-bottom: 0;
     padding: 20px;
     border: 2px;
     border-radius: 4px;
@@ -355,47 +328,73 @@ export default Vue.extend({
     height: 100%;
     flex-basis: 250px;
     flex-shrink: 0;
+    border-top: 1px solid #d8dce0;
+    border-left: 1px solid #d8dce0;
+    border-right: 1px solid #d8dce0;
 
     @include bp-down($md) {
         flex-basis: 100%;
     }
 }
 .tab {
-    padding: 16px 13px;
-    border-right: 1px solid #d8dce0;
     border-bottom: 1px solid #d8dce0;
-    border-left: 4px solid white;
     cursor: pointer;
 
     @include bp-down($md) {
-        padding: 16px 10px;
-        border-right: 0;
-        transition: max-height 0.33s;
-        position: relative;
+        border: 0;
+    }
 
-        &:after {
-            background: url('../../assets/icon-chevron-right.svg') no-repeat center center;
-            transform: rotate(90deg) translateX(-50%);
-            content: '';
-            width: 20px;
-            height: 20px;
-            @include position(absolute, 50% 20px null null);
+    &-wrap {
+        position: relative;
+        padding: 16px 13px;
+        z-index: 10;
+
+        @include bp-down($md) {
+            padding: 16px 10px;
+            border-right: 0;
+            transition: max-height 0.33s;
+
+            &:after {
+                background: url('../../assets/icon-chevron-right.svg') no-repeat center center;
+                transform: rotate(90deg) translateX(-50%);
+                content: '';
+                width: 20px;
+                height: 20px;
+                transition: all 0.33s;
+                @include position(absolute, 50% 20px null null);
+
+                .tab.active & {
+                    transform: rotate(270deg) translateX(50%);
+                }
+            }
+        }
+
+        .tab.active &:before {
+
+            @include bp-up($md) {
+                content: '';
+                width: 1px;
+                height: 100%;
+                background: #fff;
+                z-index: $z-index-top;
+                @include position(absolute, 0 -1px null null);
+            }
         }
     }
 
-    &.selected {
-        border-right: none;
-    }
-
     &-content {
-        @include position(absolute, 0 null null 250px);
+        @include position(absolute, 0 null null 251px);
         width: calc(100% - 250px);
+        z-index: $z-index-top;
+        border: 1px solid #d8dce0;
 
         @include bp-down($md) {
             padding-top: 1px;
             position: unset;
             width: 100%;
             max-height: 0;
+            border: 0;
+            border-top: 1px solid #d8dce0;
             overflow: hidden;
 
             @at-root .tab.active & {
@@ -424,11 +423,6 @@ export default Vue.extend({
         width: calc(100% + 24px);
         box-sizing: border-box;
         margin-left: -14px;
-
-        @at-root .tab.active & {
-            border-bottom: solid 1px #d8dce0;
-            padding-bottom: 14px;
-        }
     }
 }
 .undeployed,

--- a/portal/src/views/notes/NotesView.vue
+++ b/portal/src/views/notes/NotesView.vue
@@ -9,16 +9,80 @@
                     There are no stations to view.
                 </div>
                 <template v-else>
+                    <div class="station-tabs">
+                        <div class="tab"
+                            v-for="station in stations"
+                            v-bind:key="station.id"
+                            v-on:click="(ev) => onSelected(ev, station)">
+                            
+                            <div class="name">
+                                {{ station.name }}
+                            </div>
+                            <div v-if="station.deployedAt" class="deployed">Deployed</div>
+                            <div v-else class="undeployed">Not Deployed</div>
+                            <div class="tab-content" v-if="selectedStation && selectedNotes">
+                                <div class="notifications">
+                                    <div v-if="failed" class="notification failed">
+                                        Oops, there was a problem.
+                                    </div>
+
+                                    <div v-if="success" class="notification success">
+                                        Saved.
+                                    </div>
+                                </div>
+                                <NotesViewer
+                                        :station="selectedStation"
+                                        :notes="selectedNotes"
+                                        v-bind:key="stationId"
+                                        v-if="project.project.readOnly"
+                                />
+                                <NotesForm
+                                        v-else
+                                        :station="selectedStation"
+                                        :notes="selectedNotes"
+                                        @save="saveForm"
+                                        v-bind:key="stationId"
+                                        @change="onChange"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                    <!--<div class="main" v-if="selectedStation && selectedNotes">
+                        <div class="notifications">
+                            <div v-if="failed" class="notification failed">
+                                Oops, there was a problem.
+                            </div>
+
+                            <div v-if="success" class="notification success">
+                                Saved.
+                            </div>
+                        </div>
+                        <NotesViewer
+                                :station="selectedStation"
+                                :notes="selectedNotes"
+                                v-bind:key="stationId"
+                                v-if="project.project.readOnly"
+                        />
+                        <NotesForm
+                                v-else
+                                :station="selectedStation"
+                                :notes="selectedNotes"
+                                @save="saveForm"
+                                v-bind:key="stationId"
+                                @change="onChange"
+                        />
+                    </div>
+
                     <div class="side">
                         <StationTabs :stations="visibleStations" :selected="selectedStation" @selected="onSelected" />
-                    </div>
+                    </div>-->
                     <template v-if="loading">
                         <div class="main">
                             <Spinner />
                         </div>
                     </template>
                     <template v-else>
-                        <div class="main" v-if="selectedStation && selectedNotes">
+                       <!--&lt;!&ndash; <div class="main" v-if="selectedStation && selectedNotes">
                             <div class="notifications">
                                 <div v-if="failed" class="notification failed">
                                     Oops, there was a problem.
@@ -45,7 +109,7 @@
                         </div>
                         <div v-else class="main empty">
                             Please choose a station from the left.
-                        </div>
+                        </div>-->
                     </template>
                 </template>
             </div>
@@ -78,7 +142,7 @@ export default Vue.extend({
     components: {
         ...CommonComponents,
         StandardLayout,
-        StationTabs,
+     //   StationTabs,
         NotesForm,
         NotesViewer,
     },
@@ -89,6 +153,10 @@ export default Vue.extend({
         },
         stationId: {
             type: Number,
+            required: false,
+        },
+        selected: {
+            type: Object,
             required: false,
         },
     },
@@ -181,6 +249,7 @@ export default Vue.extend({
             });
         },
         onSelected(this: any, station) {
+            console.log("on selected", this, station);
             if (this.stationId != station.id) {
                 return this.$router.push({
                     name: this.projectId ? "viewProjectStationNotes" : "viewStationNotes",
@@ -245,25 +314,27 @@ export default Vue.extend({
     text-align: left;
     padding: 40px 90px;
 
+    @include bp-down($lg) {
+        padding: 40px 60px;
+    }
+
     @include bp-down($md) {
         padding: 30px 30px;
+        max-width: 600px;
     }
 
     @include bp-down($xs) {
         padding: 20px 10px;
     }
 }
-.notes-view .header {
-    margin-top: 40px;
-    display: flex;
-    flex-direction: column;
-}
+
 .notes-view .lower {
     display: flex;
     flex-direction: row;
     border: 1px solid #d8dce0;
     background: white;
     margin-top: 20px;
+    position: relative;
 }
 .notes-view .lower .side {
     flex-basis: 16rem;
@@ -298,5 +369,98 @@ export default Vue.extend({
     margin-top: 40px;
     margin-left: auto;
     margin-right: auto;
+}
+
+.station-tabs {
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    flex-basis: 250px;
+    flex-shrink: 0;
+
+    @include bp-down($md) {
+        flex-basis: 100%;
+    }
+}
+.tab {
+    padding: 16px 13px;
+    border-right: 1px solid #d8dce0;
+    border-bottom: 1px solid #d8dce0;
+    border-left: 4px solid white;
+    cursor: pointer;
+
+    @include bp-down($md) {
+        padding: 16px 10px;
+        border-right: 0;
+        transition: max-height 0.33s;
+        position: relative;
+
+        &:after {
+            background: url('../../assets/icon-chevron-right.svg') no-repeat center center;
+            transform: rotate(90deg) translateX(-50%);
+            content: '';
+            width: 20px;
+            height: 20px;
+            @include position(absolute, 50% 20px null null);
+        }
+    }
+
+    &.selected {
+        border-right: none;
+    }
+
+    &-content {
+        @include position(absolute, 0 null null 250px);
+        width: calc(100% - 250px);
+
+        @include bp-down($md) {
+            padding-top: 1px;
+            position: unset;
+            width: 100%;
+            max-height: 0;
+            overflow: hidden;
+
+            @at-root .tab.active & {
+                max-height: 1000px;
+            }
+        }
+    }
+}
+
+.vertical {
+    margin-top: auto;
+    border-right: 1px solid #d8dce0;
+    height: 100%;
+}
+.name {
+    font-size: 16px;
+    font-weight: 500;
+    color: #2c3e50;
+    margin-bottom: 1px;
+    font-weight: 500;
+}
+.undeployed {
+
+    @include bp-down($md) {
+        padding: 0 10px 0 14px;
+        width: calc(100% + 24px);
+        box-sizing: border-box;
+        margin-left: -14px;
+
+        @at-root .tab.active & {
+            border-bottom: solid 1px #d8dce0;
+            padding-bottom: 14px;
+        }
+    }
+}
+.undeployed,
+.deployed {
+    font-size: 13px;
+    color: #6a6d71;
+    font-weight: 500;
+}
+.selected {
+    border-left: 4px solid #1b80c9;
 }
 </style>

--- a/portal/src/views/notes/NotesView.vue
+++ b/portal/src/views/notes/NotesView.vue
@@ -21,6 +21,9 @@
                                 <div v-else class="undeployed">Not Deployed</div>
                             </div>
                             <div class="tab-content" v-if="selectedStation && selectedNotes">
+                                <div v-if="loading" class="main">
+                                    <Spinner />
+                                </div>
                                 <div class="notifications">
                                     <div v-if="failed" class="notification failed">
                                         Oops, there was a problem.
@@ -45,46 +48,11 @@
                                         @change="onChange"
                                 />
                             </div>
-                            <div v-else class="main empty">
+                            <div v-else class="tab-content empty">
                                 Please choose a station from the left.
                             </div>
                         </div>
                     </div>
-                    <template v-if="loading">
-                        <div class="main">
-                            <Spinner />
-                        </div>
-                    </template>
-                    <template v-else>
-                       <!--&lt;!&ndash; <div class="main" v-if="selectedStation && selectedNotes">
-                            <div class="notifications">
-                                <div v-if="failed" class="notification failed">
-                                    Oops, there was a problem.
-                                </div>
-
-                                <div v-if="success" class="notification success">
-                                    Saved.
-                                </div>
-                            </div>
-                            <NotesViewer
-                                :station="selectedStation"
-                                :notes="selectedNotes"
-                                v-bind:key="stationId"
-                                v-if="project.project.readOnly"
-                            />
-                            <NotesForm
-                                v-else
-                                :station="selectedStation"
-                                :notes="selectedNotes"
-                                @save="saveForm"
-                                v-bind:key="stationId"
-                                @change="onChange"
-                            />
-                        </div>
-                        <div v-else class="main empty">
-                            Please choose a station from the left.
-                        </div>-->
-                    </template>
                 </template>
             </div>
         </div>
@@ -116,7 +84,6 @@ export default Vue.extend({
     components: {
         ...CommonComponents,
         StandardLayout,
-     //   StationTabs,
         NotesForm,
         NotesViewer,
     },
@@ -223,12 +190,11 @@ export default Vue.extend({
             });
         },
         onSelected(station) {
-            console.log("on selected", station);
             if (this.stationId != station.id) {
                 return this.$router.push({
                     name: this.projectId ? "viewProjectStationNotes" : "viewStationNotes",
                     params: {
-                        projectId: this.projectId,
+                        projectId: this.projectId.toString(),
                         stationId: station.id,
                     },
                 });
@@ -344,6 +310,14 @@ export default Vue.extend({
         border: 0;
     }
 
+    &.active {
+        border-left: 4px solid #1b80c9;
+
+        @include bp-down($md) {
+            border-left: 0;
+        }
+    }
+
     &-wrap {
         position: relative;
         padding: 16px 13px;
@@ -373,11 +347,11 @@ export default Vue.extend({
 
             @include bp-up($md) {
                 content: '';
-                width: 1px;
+                width: 3px;
                 height: 100%;
                 background: #fff;
                 z-index: $z-index-top;
-                @include position(absolute, 0 -1px null null);
+                @include position(absolute, 0 -2px null null);
             }
         }
     }
@@ -400,6 +374,10 @@ export default Vue.extend({
             @at-root .tab.active & {
                 max-height: 1000px;
             }
+        }
+
+        &.empty {
+            padding: 20px;
         }
     }
 }
@@ -430,8 +408,5 @@ export default Vue.extend({
     font-size: 13px;
     color: #6a6d71;
     font-weight: 500;
-}
-.selected {
-    border-left: 4px solid #1b80c9;
 }
 </style>

--- a/portal/src/views/notes/NotesView.vue
+++ b/portal/src/views/notes/NotesView.vue
@@ -1,6 +1,6 @@
 <template>
     <StandardLayout>
-        <div class="notes-view">
+        <div class="container-wrap notes-view">
             <DoubleHeader :title="project.name" subtitle="Field Notes" backTitle="Back to Dashboard" backRoute="projects" v-if="project" />
             <DoubleHeader title="My Stations" subtitle="Field Notes" backTitle="Back to Dashboard" backRoute="projects" v-if="!project" />
 
@@ -14,7 +14,7 @@
                             v-for="station in stations"
                             v-bind:key="station.id"
                             v-on:click="(ev) => onSelected(ev, station)">
-                            
+
                             <div class="name">
                                 {{ station.name }}
                             </div>
@@ -303,30 +303,7 @@ export default Vue.extend({
 </script>
 
 <style scoped lang="scss">
-@import '../../scss/mixins';
-
-.notes-view {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    max-width: 1080px;
-    background-color: #fcfcfc;
-    text-align: left;
-    padding: 40px 90px;
-
-    @include bp-down($lg) {
-        padding: 40px 60px;
-    }
-
-    @include bp-down($md) {
-        padding: 30px 30px;
-        max-width: 600px;
-    }
-
-    @include bp-down($xs) {
-        padding: 20px 10px;
-    }
-}
+@import '../../scss/layout';
 
 .notes-view .lower {
     display: flex;

--- a/portal/src/views/notes/NotesView.vue
+++ b/portal/src/views/notes/NotesView.vue
@@ -233,14 +233,25 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/mixins';
+
 .notes-view {
     display: flex;
     flex-direction: column;
     height: 100%;
+    max-width: 1080px;
     background-color: #fcfcfc;
     text-align: left;
-    padding: 40px;
+    padding: 40px 90px;
+
+    @include bp-down($md) {
+        padding: 30px 30px;
+    }
+
+    @include bp-down($xs) {
+        padding: 20px 10px;
+    }
 }
 .notes-view .header {
     margin-top: 40px;
@@ -280,7 +291,7 @@ export default Vue.extend({
     background-color: #f8d7da;
 }
 .notifications {
-    padding: 10px;
+    padding: 0 10px;
 }
 
 .spinner {

--- a/portal/src/views/notes/StationTabs.vue
+++ b/portal/src/views/notes/StationTabs.vue
@@ -7,13 +7,11 @@
             v-on:click="(ev) => clicked(ev, station)"
             v-bind:class="{ selected: selected && station.id == selected.id }"
         >
-            <div class="tab-container">
-                <div class="name">
-                    {{ station.name }}
-                </div>
-                <div v-if="station.deployedAt" class="deployed">Deployed</div>
-                <div v-else class="undeployed">Not Deployed</div>
+            <div class="name">
+                {{ station.name }}
             </div>
+            <div v-if="station.deployedAt" class="deployed">Deployed</div>
+            <div v-else class="undeployed">Not Deployed</div>
         </div>
         <div class="vertical">&nbsp;</div>
     </div>
@@ -52,7 +50,7 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .station-tabs {
     text-align: left;
     display: flex;
@@ -60,16 +58,17 @@ export default Vue.extend({
     height: 100%;
 }
 .tab {
-    padding: 10px;
+    padding: 16px 13px;
     border-right: 1px solid #d8dce0;
     border-bottom: 1px solid #d8dce0;
     border-left: 4px solid white;
+    cursor: pointer;
+
+    &.selected {
+        border-right: none;
+    }
 }
-.tab:not(:last-child) {
-}
-.tab-container {
-    padding: 10px;
-}
+
 .vertical {
     margin-top: auto;
     border-right: 1px solid #d8dce0;
@@ -79,11 +78,14 @@ export default Vue.extend({
     font-size: 16px;
     font-weight: 500;
     color: #2c3e50;
+    margin-bottom: 1px;
+    font-weight: 500;
 }
 .undeployed,
 .deployed {
     font-size: 13px;
     color: #6a6d71;
+    font-weight: 500;
 }
 .selected {
     border-left: 4px solid #1b80c9;

--- a/portal/src/views/projects/ProjectEditView.vue
+++ b/portal/src/views/projects/ProjectEditView.vue
@@ -72,15 +72,16 @@ export default Vue.extend({
     padding: 65px 87px 60px;
 
     @include bp-down($lg) {
-        padding: 10px 45px 60px;
+        padding: 45px 45px 60px;
+        align-items: center;
     }
 
     @include bp-down($sm) {
-        padding: 0 20px 30px;
+        padding: 45px 20px 30px;
     }
 
     @include bp-down($xs) {
-        padding: 0 10px 30px;
+        padding: 0;
     }
 }
 .small-arrow {

--- a/portal/src/views/projects/ProjectEditView.vue
+++ b/portal/src/views/projects/ProjectEditView.vue
@@ -63,27 +63,8 @@ export default Vue.extend({
 
 <style scoped lang="scss">
 @import '../../scss/mixins';
-.main-panel {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    background-color: #fcfcfc;
-    text-align: left;
-    padding: 65px 87px 60px;
+@import '../../scss/layout';
 
-    @include bp-down($lg) {
-        padding: 45px 45px 60px;
-        align-items: center;
-    }
-
-    @include bp-down($sm) {
-        padding: 45px 20px 30px;
-    }
-
-    @include bp-down($xs) {
-        padding: 0;
-    }
-}
 .small-arrow {
     font-size: 11px;
     float: left;

--- a/portal/src/views/projects/ProjectEditView.vue
+++ b/portal/src/views/projects/ProjectEditView.vue
@@ -61,14 +61,27 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/mixins';
 .main-panel {
     display: flex;
     flex-direction: column;
     height: 100%;
     background-color: #fcfcfc;
     text-align: left;
-    padding: 40px;
+    padding: 65px 87px 60px;
+
+    @include bp-down($lg) {
+        padding: 10px 45px 60px;
+    }
+
+    @include bp-down($sm) {
+        padding: 0 20px 30px;
+    }
+
+    @include bp-down($xs) {
+        padding: 0 10px 30px;
+    }
 }
 .small-arrow {
     font-size: 11px;

--- a/portal/src/views/projects/ProjectForm.vue
+++ b/portal/src/views/projects/ProjectForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="project-form">
+    <div class="form-edit">
         <div class="header-row">
             <h2 v-if="!project">New Project</h2>
             <h2 v-if="project && project.id">Edit Project</h2>
@@ -372,20 +372,7 @@ export default Vue.extend({
 
 <style scoped lang="scss">
 @import '../../scss/mixins';
-
-.project-form {
-    display: flex;
-    flex-direction: column;
-    border: 1px solid #d8dce0;
-    background: white;
-    padding: 0 22px 14px;
-    max-width: 700px;
-    position: relative;
-
-    @include bp-down($xs) {
-        padding: 0 10px 14px;
-    }
-}
+@import '../../scss/forms';
 
 form > .outer-input-container {
     margin-bottom: 20px;
@@ -553,17 +540,6 @@ form > .outer-input-container {
     display: block;
     font-size: 14px;
     margin-bottom: 25px;
-}
-
-::v-deep .outer-input-container {
-
-    .has-float-label > input {
-        border-bottom: 1px solid #d8dce0;
-    }
-
-    span {
-        top: -4px;
-    }
 }
 
 .tags {

--- a/portal/src/views/projects/ProjectForm.vue
+++ b/portal/src/views/projects/ProjectForm.vue
@@ -108,12 +108,11 @@
                 </div>
             </div>
             <div class="action-container">
-                <button class="save-button" v-if="!project" type="submit">Add</button>
-                <button class="save-button" v-if="project && project.id" type="submit">Update</button>
-                <div v-if="project && project.id" class="delete-container" v-on:click="deleteProject">
-                    <img alt="Delete" src="@/assets/Delete.png" />
-                    Delete this project
-                </div>
+                <button class="btn" v-if="!project" type="submit"> Add project </button>
+                <button class="btn" v-if="project && project.id" type="submit"> Save updates </button>
+                <button v-if="project && project.id" class="btn btn-delete" type="submit" v-on:click="deleteProject">
+                    Delete Project
+                </button>
             </div>
         </form>
     </div>
@@ -361,13 +360,17 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/mixins';
+
 .project-form {
     display: flex;
     flex-direction: column;
     border: 1px solid #d8dce0;
     background: white;
-    padding: 20px;
+    padding: 0 22px 14px;
+    max-width: 700px;
+    position: relative;
 }
 
 form > div {
@@ -388,9 +391,9 @@ form > div {
 }
 .image-container {
     width: 100%;
-    margin: 15px 0;
+    margin: 28px 0 15px;
 }
-/deep/ .image-container img {
+::v-deep .image-container img {
     max-width: 275px;
     max-height: 135px;
     margin-right: 10px;
@@ -398,12 +401,15 @@ form > div {
 .date-container {
     flex: 1;
     display: flex;
+    position: relative;
 }
 .date-container .outer-input-container {
     flex-grow: 1;
 }
 .date-container button {
     position: absolute;
+    bottom: 5px;
+    right: 0;
     margin: -4px 0 0 -30px;
     background: none;
     padding: 0;
@@ -412,7 +418,6 @@ form > div {
 .date-container img {
     vertical-align: bottom;
     padding-bottom: 2px;
-    margin-left: 4px;
 }
 
 #public-checkbox-container {
@@ -450,31 +455,32 @@ form > div {
 
 .action-container {
     display: flex;
-    align-items: baseline;
 }
-.save-button {
+.close-form-button {
+    cursor: pointer;
+    @include position(absolute, 14px 14px null null);
+}
+.btn {
     width: 300px;
-    height: 50px;
+    height: 45px;
     font-size: 18px;
     color: white;
     background-color: #ce596b;
     border: none;
     border-radius: 5px;
+    font-weight: 900;
+    letter-spacing: 0.1px;
+
+    &-delete {
+        margin-left: 18px;
+        background: #fff;
+        width: 215px;
+        height: 45px;
+        border: 1px solid #ce596b;
+        color: #ce596b;
+    }
 }
-.close-form-button {
-    margin-left: auto;
-    margin-top: 15px;
-    cursor: pointer;
-}
-.delete-container {
-    margin-left: auto;
-    cursor: pointer;
-    display: inline-block;
-}
-.delete-container img {
-    width: 12px;
-    margin-right: 4px;
-}
+
 .validation-errors {
     color: #c42c44;
     display: block;
@@ -482,7 +488,18 @@ form > div {
     margin-bottom: 25px;
 }
 
-/deep/ .ti-tag {
+::v-deep .ti-tag {
     background-color: #0a67aa;
+}
+
+::v-deep .outer-input-container {
+
+    input {
+        border-bottom: 1px solid #d8dce0;
+    }
+
+    span {
+        top: -4px;
+    }
 }
 </style>

--- a/portal/src/views/projects/ProjectForm.vue
+++ b/portal/src/views/projects/ProjectForm.vue
@@ -83,8 +83,9 @@
                 </div>
             </div>
 
-            <div class="outer-input-container">
-                <vue-tags-input v-model="form.tag" :tags="form.tags" @tags-changed="onTagsChanged" />
+            <div class="outer-input-container tags-container">
+                <span class="tags-placeholder js-tagsPlaceholder"> Tags </span>
+                <vue-tags-input v-model="form.tag" :tags="form.tags" @tags-changed="onTagsChanged" @blur="onTagsFocus" @focus="onTagsFocus" placeholder="" />
 
                 <div class="validation-errors" v-if="$v.form.tags.$error">
                     <div v-if="!$v.form.tags.maxLength">This field has a limit of 100 characters.</div>
@@ -97,14 +98,14 @@
                 </div>
 
                 <div v-if="form.public" class="public-options">
-                    <div class="privacy-field">
+                    <label class="privacy-field">
                         <input type="radio" id="privacy" value="1" v-model="form.privacy" />
-                        Show exact location of stations.
-                    </div>
-                    <div class="privacy-field">
+                        Show exact location of stations
+                    </label>
+                    <label class="privacy-field">
                         <input type="radio" id="privacy" value="2" v-model="form.privacy" />
-                        Show general location of stations.
-                    </div>
+                        Show general location of stations
+                    </label>
                 </div>
             </div>
             <div class="action-container">
@@ -243,6 +244,10 @@ export default Vue.extend({
         },
     },
     methods: {
+        onTagsFocus(e) {
+            console.log("z", e);
+            document.querySelector('.js-tagsPlaceholder').classList.toggle('focused');
+        },
         saveForm() {
             this.$v.form.$touch();
             if (this.$v.form.$pending || this.$v.form.$error) {
@@ -440,12 +445,36 @@ form > div {
 
 #public-checkbox-container .privacy-field {
     display: flex;
+
+    input {
+        opacity: 0;
+        position: absolute;
+        z-index: -1;
+    }
+
+    &:nth-of-type(1) {
+        color: red;
+    }
 }
 
 #public-checkbox-container .public-options {
     display: flex;
     flex-direction: column;
     margin-left: 1em;
+
+    .privacy-field {
+        padding-left: 8px;
+        position: relative;
+
+        &:before {
+            content: '';
+            width: 22px;
+            height: 22px;
+            border-radius: 100px;
+            border: solid 1px rgba(0, 0, 0, 0.1);
+            @include position(absolute, 0 null null 0);
+        }
+    }
 }
 
 .outer-date-container {
@@ -502,4 +531,74 @@ form > div {
         top: -4px;
     }
 }
+
+.tags {
+
+    &-placeholder {
+        font-size: 100%;
+        color: #6a6d71;
+        transition: all 0.2s;
+        cursor: text;
+        z-index: $z-index-top;
+        @include position(absolute, 0.9em null null 0);
+
+        &.focused {
+            font-size: 75%;
+            top: 0;
+        }
+    }
+
+    &-container {
+        position: relative;
+        padding-top: 1em;
+    }
+}
+
+::v-deep .vue-tags-input {
+
+    .ti-input {
+        border: 0;
+        padding: 0;
+    }
+
+    .ti-new-tag-input {
+        font-size: 16px;
+
+        &-wrapper {
+            padding: 0;
+            margin: 0;
+        }
+    }
+
+    .ti-tag {
+        color: #2c3e50;
+        font-size: 13px;
+        height: 20px;
+        border-radius: 10px;
+        background-color: #f4f5f7;
+    }
+
+    .ti-icon-close {
+        width: 10px;
+        height: 10px;
+        background: url('../../assets/icon-close.svg') no-repeat center center;
+        background-size: 10px;
+        background-color: transparent;
+
+        &:before {
+            content: '';
+        }
+    }
+
+    .ti-deletion-mark {
+        background: #ce596b!important;
+        color: white;
+
+        .ti-icon-close {
+            background: url('../../assets/icon-close-white.svg') no-repeat center center;
+            background-size: 10px;
+        }
+    }
+}
+
 </style>

--- a/portal/src/views/projects/ProjectForm.vue
+++ b/portal/src/views/projects/ProjectForm.vue
@@ -47,63 +47,64 @@
             </div>
 
             <div class="dates-row">
-                <div class="outer-date-container">
-                    <div class="date-container">
-                        <div class="outer-input-container">
-                            <TextField v-model="form.startTime" label="Start" />
-                        </div>
-                        <v-date-picker :value="form.pickedStart" @input="updateStart" :popover="{ placement: 'auto', visibility: 'click' }">
-                            <button type="button">
-                                <img alt="Calendar" src="@/assets/calendar.png" />
-                            </button>
-                        </v-date-picker>
+                <div class="date-container">
+                    <div class="outer-input-container">
+                        <TextField v-model="form.startTime" label="Start" />
                     </div>
-
-                    <div class="validation-errors" v-if="$v.form.startTime.$error">
-                        <div v-if="!$v.form.startTime.date">Please enter a valid date.</div>
-                    </div>
+                    <v-date-picker :value="form.pickedStart" @input="updateStart" :popover="{ placement: 'auto', visibility: 'click' }">
+                        <button type="button">
+                            <img alt="Calendar" src="@/assets/calendar.png" />
+                        </button>
+                    </v-date-picker>
                 </div>
-                <div class="space-hack"></div>
-                <div class="outer-date-container">
-                    <div class="date-container">
-                        <div class="outer-input-container">
-                            <TextField v-model="form.endTime" label="End" />
-                        </div>
-                        <v-date-picker :value="form.pickedEnd" @input="updateEnd" :popover="{ placement: 'auto', visibility: 'click' }">
-                            <button type="button">
-                                <img alt="Calendar" src="@/assets/calendar.png" />
-                            </button>
-                        </v-date-picker>
-                    </div>
 
-                    <div class="validation-errors" v-if="$v.form.endTime.$error">
-                        <div v-if="!$v.form.endTime.date">Please enter a valid date.</div>
-                        <div v-if="!$v.form.endTime.minValue">Please enter a date after the start date.</div>
+                <div class="validation-errors" v-if="$v.form.startTime.$error">
+                    <div v-if="!$v.form.startTime.date">Please enter a valid date.</div>
+                </div>
+
+                <div class="date-container">
+                    <div class="outer-input-container">
+                        <TextField v-model="form.endTime" label="End" />
                     </div>
+                    <v-date-picker :value="form.pickedEnd" @input="updateEnd" :popover="{ placement: 'auto', visibility: 'click' }">
+                        <button type="button">
+                            <img alt="Calendar" src="@/assets/calendar.png" />
+                        </button>
+                    </v-date-picker>
+                </div>
+
+                <div class="validation-errors" v-if="$v.form.endTime.$error">
+                    <div v-if="!$v.form.endTime.date">Please enter a valid date.</div>
+                    <div v-if="!$v.form.endTime.minValue">Please enter a date after the start date.</div>
                 </div>
             </div>
 
             <div class="outer-input-container tags-container">
-                <span class="tags-placeholder js-tagsPlaceholder"> Tags </span>
-                <vue-tags-input v-model="form.tag" :tags="form.tags" @tags-changed="onTagsChanged" @blur="onTagsFocus" @focus="onTagsFocus" placeholder="" />
+                <span class="js-tagsPlaceholder" v-bind:class="{focused: form.tags}"> Tags </span>
+                <vue-tags-input v-model="form.tag" :tags="form.tags" @tags-changed="onTagsChanged" @blur="onTagsBlur" @focus="onTagsFocus" placeholder="" />
 
                 <div class="validation-errors" v-if="$v.form.tags.$error">
                     <div v-if="!$v.form.tags.maxLength">This field has a limit of 100 characters.</div>
                 </div>
             </div>
-            <div id="public-checkbox-container">
-                <div class="privacy-field">
-                    <input type="checkbox" id="checkbox" v-model="form.public" />
-                    <label for="checkbox">Make this project public</label>
+            <div class="privacy">
+                <div class="checkbox">
+                    <label>
+                        Make this project public
+                        <input type="checkbox" id="checkbox" v-model="form.public" />
+                        <span class="checkbox-btn"></span>
+                    </label>
                 </div>
 
-                <div v-if="form.public" class="public-options">
-                    <label class="privacy-field">
+                <div v-if="form.public" class="radio-container">
+                    <label class="radio">
                         <input type="radio" id="privacy" value="1" v-model="form.privacy" />
+                        <span class="radio-btn"></span>
                         Show exact location of stations
                     </label>
-                    <label class="privacy-field">
+                    <label class="radio">
                         <input type="radio" id="privacy" value="2" v-model="form.privacy" />
+                        <span class="radio-btn"></span>
                         Show general location of stations
                     </label>
                 </div>
@@ -245,8 +246,12 @@ export default Vue.extend({
     },
     methods: {
         onTagsFocus(e) {
-            console.log("z", e);
-            document.querySelector('.js-tagsPlaceholder').classList.toggle('focused');
+            document.querySelector('.js-tagsPlaceholder').classList.add('focused');
+        },
+        onTagsBlur(e) {
+           // if (!this.$v.form.tags || this.$v.form.tags.length > 0) {
+                document.querySelector('.js-tagsPlaceholder').classList.remove('focused');
+           // }
         },
         saveForm() {
             this.$v.form.$touch();
@@ -376,9 +381,13 @@ export default Vue.extend({
     padding: 0 22px 14px;
     max-width: 700px;
     position: relative;
+
+    @include bp-down($xs) {
+        padding: 0 10px 14px;
+    }
 }
 
-form > div {
+form > .outer-input-container {
     margin-bottom: 20px;
 }
 
@@ -388,8 +397,9 @@ form > div {
 }
 
 .dates-row {
-    display: flex;
+    @include flex(center, space-between);
     flex-direction: row;
+    margin-bottom: 20px;
 }
 .dates-row > div {
     flex: 1;
@@ -407,6 +417,7 @@ form > div {
     flex: 1;
     display: flex;
     position: relative;
+    max-width: 200px;
 }
 .date-container .outer-input-container {
     flex-grow: 1;
@@ -425,26 +436,15 @@ form > div {
     padding-bottom: 2px;
 }
 
-#public-checkbox-container {
-    margin: 15px 0;
-    width: 98%;
-    padding-bottom: 20px;
-}
-#public-checkbox-container input {
-    float: left;
-    margin: 5px;
-}
-#public-checkbox-container label {
-    float: left;
-    margin: 2px 5px;
-}
-#public-checkbox-container img {
-    float: left;
-    margin: 2px 5px;
+.privacy {
+    margin: 34px 0;
 }
 
-#public-checkbox-container .privacy-field {
-    display: flex;
+.radio {
+    padding-left: 32px;
+    margin: 7px 0;
+    position: relative;
+    cursor: pointer;
 
     input {
         opacity: 0;
@@ -452,45 +452,79 @@ form > div {
         z-index: -1;
     }
 
-    &:nth-of-type(1) {
-        color: red;
+    &-btn {
+        content: '';
+        width: 20px;
+        height: 20px;
+        border-radius: 100px;
+        border: solid 1px rgba(0, 0, 0, 0.1);
+        background: #f2f4f7;
+        @include position(absolute, 0 null null 0);
     }
-}
 
-#public-checkbox-container .public-options {
-    display: flex;
-    flex-direction: column;
-    margin-left: 1em;
+    &-container {
+        display: flex;
+        flex-direction: column;
+        margin-left: 27px;
+    }
 
-    .privacy-field {
-        padding-left: 8px;
-        position: relative;
+    input:checked ~ .radio-btn {
 
-        &:before {
+        &:after {
+            @include position(absolute, 5px null null 5px);
             content: '';
-            width: 22px;
-            height: 22px;
-            border-radius: 100px;
-            border: solid 1px rgba(0, 0, 0, 0.1);
-            @include position(absolute, 0 null null 0);
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background-color: #2c3e50;
         }
     }
 }
 
-.outer-date-container {
-    display: flex;
-    flex-direction: column;
+.checkbox {
+    position: relative;
+    padding-left: 30px;
+    margin: 7px 0;
+    cursor: pointer;
+
+    input {
+        opacity: 0;
+        position: absolute;
+        z-index: -1;
+    }
+
+    &-btn {
+        width: 18px;
+        height: 18px;
+        border-radius: 2px;
+        border: solid 1px rgba(0, 0, 0, 0.1);
+        background: #f2f4f7;
+        @include position(absolute, 0 null null 0);
+    }
+
+    input:checked ~ .checkbox-btn {
+
+        &:after {
+            @include position(absolute, 0 null null 0);
+            content: '';
+            background: url('../../assets/icon-tick.svg') no-repeat center center;
+            background-size: 10px 8px;
+            width: 20px;
+            height: 20px;
+        }
+    }
 }
 
 .action-container {
     display: flex;
+    flex-wrap: wrap;
 }
 .close-form-button {
     cursor: pointer;
     @include position(absolute, 14px 14px null null);
 }
 .btn {
-    width: 300px;
+    width: 280px;
     height: 45px;
     font-size: 18px;
     color: white;
@@ -499,9 +533,13 @@ form > div {
     border-radius: 5px;
     font-weight: 900;
     letter-spacing: 0.1px;
+    margin-bottom: 20px;
+
+    &:nth-of-type(1) {
+        margin-right: 18px;
+    }
 
     &-delete {
-        margin-left: 18px;
         background: #fff;
         width: 215px;
         height: 45px;
@@ -517,13 +555,9 @@ form > div {
     margin-bottom: 25px;
 }
 
-::v-deep .ti-tag {
-    background-color: #0a67aa;
-}
-
 ::v-deep .outer-input-container {
 
-    input {
+    .has-float-label > input {
         border-bottom: 1px solid #d8dce0;
     }
 
@@ -534,31 +568,33 @@ form > div {
 
 .tags {
 
-    &-placeholder {
-        font-size: 100%;
-        color: #6a6d71;
-        transition: all 0.2s;
-        cursor: text;
-        z-index: $z-index-top;
-        @include position(absolute, 0.9em null null 0);
-
-        &.focused {
-            font-size: 75%;
-            top: 0;
-        }
-    }
-
     &-container {
         position: relative;
         padding-top: 1em;
+
+        > span {
+            font-size: 100%;
+            color: #6a6d71;
+            transition: all 0.2s;
+            cursor: text;
+            z-index: $z-index-top;
+            @include position(absolute, 11px null null 0);
+
+            &.focused {
+                font-size: 75%;
+                top: -4px;
+            }
+        }
     }
 }
 
 ::v-deep .vue-tags-input {
+    max-width: unset;
 
     .ti-input {
         border: 0;
-        padding: 0;
+        border-bottom: 1px solid #d8dce0;
+        padding: 0 0 3px 0;
     }
 
     .ti-new-tag-input {

--- a/portal/src/views/projects/ProjectView.vue
+++ b/portal/src/views/projects/ProjectView.vue
@@ -1,34 +1,36 @@
 <template>
     <StandardLayout :viewingProjects="true" :viewingProject="displayProject" :disableScrolling="activityVisible">
-        <div class="project-view" v-if="displayProject">
-            <DoubleHeader
-                :title="displayProject.name"
-                subtitle="Project Dashbord"
-                backTitle="Back to Dashboard"
-                backRoute="projects"
-                v-if="displayProject"
-            >
-                <div class="activity-button" v-on:click="onActivityToggle">
-                    Activity
-                </div>
-            </DoubleHeader>
+        <div class="container-wrap">
+            <div class="project-view" v-if="displayProject">
+                <DoubleHeader
+                        :title="displayProject.name"
+                        subtitle="Project Dashbord"
+                        backTitle="Back to Dashboard"
+                        backRoute="projects"
+                        v-if="displayProject"
+                >
+                    <div class="activity-button" v-on:click="onActivityToggle">
+                        Activity
+                    </div>
+                </DoubleHeader>
 
-            <div v-bind:key="id">
-                <ProjectActivity
-                    v-if="activityVisible"
-                    :user="user"
-                    :displayProject="displayProject"
-                    containerClass="project-activity-floating"
-                    @close="closeActivity"
-                />
-                <div class="">
-                    <ProjectAdmin v-if="isAdministrator" :user="user" :displayProject="displayProject" :userStations="stations" />
-                    <ProjectPublic
-                        v-if="!isAdministrator && displayProject"
-                        :user="user"
-                        :displayProject="displayProject"
-                        :userStations="stations"
+                <div v-bind:key="id">
+                    <ProjectActivity
+                            v-if="activityVisible"
+                            :user="user"
+                            :displayProject="displayProject"
+                            containerClass="project-activity-floating"
+                            @close="closeActivity"
                     />
+                    <div class="">
+                        <ProjectAdmin v-if="isAdministrator" :user="user" :displayProject="displayProject" :userStations="stations" />
+                        <ProjectPublic
+                                v-if="!isAdministrator && displayProject"
+                                :user="user"
+                                :displayProject="displayProject"
+                                :userStations="stations"
+                        />
+                    </div>
                 </div>
             </div>
         </div>
@@ -126,15 +128,9 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
-.project-view {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    background-color: #fcfcfc;
-    padding: 40px;
-    text-align: left;
-}
+<style scoped lang="scss">
+@import '../../scss/layout';
+
 .small-arrow {
     font-size: 11px;
     float: left;

--- a/portal/src/views/shared/ImageUploader.vue
+++ b/portal/src/views/shared/ImageUploader.vue
@@ -94,6 +94,7 @@ label {
     transform: translateY(-7px);
     font-size: 14px;
     cursor: pointer;
+    margin-left: 12px;
 
     @include bp-down($xs) {
         width: 100%;

--- a/portal/src/views/shared/ImageUploader.vue
+++ b/portal/src/views/shared/ImageUploader.vue
@@ -99,7 +99,8 @@ label {
     @include bp-down($xs) {
         width: 100%;
         display: block;
-        margin-top: 7px;
+        transform: translateY(5px);
+        margin-left: 0;
     }
 }
 

--- a/portal/src/views/shared/ImageUploader.vue
+++ b/portal/src/views/shared/ImageUploader.vue
@@ -105,8 +105,6 @@ label {
 }
 
 input {
-    opacity: 0;
-    position: absolute;
-    z-index: -1;
+    display: none;
 }
 </style>

--- a/portal/src/views/shared/ImageUploader.vue
+++ b/portal/src/views/shared/ImageUploader.vue
@@ -3,7 +3,6 @@
         <img alt="Image" :src="placeholderImage" v-if="!image || (!image.url && !preview)" />
         <img alt="Image" :src="$config.baseUrl + image.url" class="image" v-if="image && image.url && !preview" />
         <img alt="Image" :src="preview" class="image" v-if="preview" />
-        <br />
         <label for="imageInput">
             <template v-if="!preview"> Choose Image </template>
             <template v-if="preview"> Change Image </template>
@@ -83,22 +82,29 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped>
+<style scoped lang="scss">
+@import '../../scss/mixins';
 
-    .image-container {
-        display: flex;
-        align-items: baseline;
-    }
+.image-container {
+    @include flex(baseline);
+    flex-wrap: wrap;
+}
 
-    label {
-        transform: translateY(-7px);
-        font-size: 14px;
-        cursor: pointer;
-    }
+label {
+    transform: translateY(-7px);
+    font-size: 14px;
+    cursor: pointer;
 
-    input {
-        opacity: 0;
-        position: absolute;
-        z-index: -1;
+    @include bp-down($xs) {
+        width: 100%;
+        display: block;
+        margin-top: 7px;
     }
+}
+
+input {
+    opacity: 0;
+    position: absolute;
+    z-index: -1;
+}
 </style>

--- a/portal/src/views/shared/ImageUploader.vue
+++ b/portal/src/views/shared/ImageUploader.vue
@@ -4,7 +4,11 @@
         <img alt="Image" :src="$config.baseUrl + image.url" class="image" v-if="image && image.url && !preview" />
         <img alt="Image" :src="preview" class="image" v-if="preview" />
         <br />
-        <input type="file" accept="image/gif, image/jpeg, image/png" @change="upload" />
+        <label for="imageInput">
+            <template v-if="!preview"> Choose Image </template>
+            <template v-if="preview"> Change Image </template>
+        </label>
+        <input id="imageInput" type="file" accept="image/gif, image/jpeg, image/png" @change="upload" />
     </div>
 </template>
 
@@ -79,4 +83,22 @@ export default Vue.extend({
 });
 </script>
 
-<style scoped></style>
+<style scoped>
+
+    .image-container {
+        display: flex;
+        align-items: baseline;
+    }
+
+    label {
+        transform: translateY(-7px);
+        font-size: 14px;
+        cursor: pointer;
+    }
+
+    input {
+        opacity: 0;
+        position: absolute;
+        z-index: -1;
+    }
+</style>

--- a/portal/src/views/shared/SidebarNav.vue
+++ b/portal/src/views/shared/SidebarNav.vue
@@ -82,7 +82,7 @@ export default {
     transition: width 0.33s;
     overflow: hidden;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.28);
-    z-index: $z-index-top;
+    z-index: $z-index-menu;
 
     &.active {
         width: 240px;

--- a/portal/src/views/shared/TextAreaField.vue
+++ b/portal/src/views/shared/TextAreaField.vue
@@ -23,7 +23,7 @@ const ResizeAuto = Vue.extend({
     mounted() {
         this.$nextTick(() => {
             const el: any = this.$el;
-            el.setAttribute("style", "height:" + this.$el.scrollHeight + "px");
+            el.setAttribute("style", "height:" + (this.$el.scrollHeight - 0) + "px");
         });
 
         this.$el.addEventListener("input", this.resize);
@@ -31,7 +31,7 @@ const ResizeAuto = Vue.extend({
     updated() {
         this.$nextTick(() => {
             const el: any = this.$el;
-            el.setAttribute("style", "height:" + this.$el.scrollHeight + "px");
+            el.setAttribute("style", "height:" + (this.$el.scrollHeight - 0) + "px");
         });
     },
     beforeDestroy() {
@@ -77,13 +77,13 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+
 .has-float-label textarea {
     width: 100%;
     font-family: "Avenir", Helvetica, Arial, sans-serif;
-}
-.has-float-label textarea {
+    box-sizing: border-box;
     font-size: inherit;
-    padding-top: 1em;
+    padding-top: 0.5em;
     margin-bottom: 2px;
     border: 0;
     border-radius: 0;

--- a/portal/src/views/shared/TextField.vue
+++ b/portal/src/views/shared/TextField.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
 .has-float-label > span {
     position: absolute;
     left: 0;
-    top: 0;
+    top: -4px;
     cursor: text;
     font-size: 75%;
     opacity: 1;
@@ -87,7 +87,7 @@ export default Vue.extend({
     margin-bottom: 2px;
     border: 0;
     border-radius: 0;
-    border-bottom: 2px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 1px solid #d8dce0;
 
     &:focus {
         &::placeholder {


### PR DESCRIPTION
CSS/HTML fixes to adapt to the design on desktop and mobile

Had to restructure the NotesView so that the NotesViewer and NotesForm are inside each instance of Stations Tab.
I left the Stations Tab untouched, and instead moved the required html and css to the parent (NotesView).

Unfortunately this means the functionality is now broken, and due to the time constraints to deliver this task I was not able to fix it. Will discuss with Susan if I should take care of this next week.

Loads of commented code left there to help me recover the functionality.

Please let me know if you think I should dispose of the StationTabs component or there are any future plans to use it somewhere else.


