### PR TITLE
Fk 2993 map dots not appearing

### DIFF
--- a/portal/src/views/shared/StationsMap.vue
+++ b/portal/src/views/shared/StationsMap.vue
@@ -101,42 +101,25 @@ export default Vue.extend({
             console.log("map: loaded");
             this.protectedData.map = map;
 
-            this.loadCompassImage(map)
-                .then(() => {
-                    setTimeout(() => {
-                        console.log("ressize");
-                        map.resize();
-
-                        this.ready = true;
-                        this.updateMap();
-
-                        // Force model to update.
-                        this.newBounds();
-                    }, 100);
-                })
-                .catch((error) => {
-                    throw error;
+            if (!map.hasImage("dot")) {
+                const compass = this.$loadAsset("Icon_Map_Dot.png");
+                map.loadImage(compass, (error, image) => {
+                    if (error) throw error;
+                    if (!map.hasImage("dot")) {
+                        map.addImage("dot", image);
+                    }
                 });
-        },
-        loadCompassImage(map) {
-            // return new Promise((resolve => resolve()));
-            return new Promise((resolve, reject) => {
-                console.log('map.hasImage("dot")', map.hasImage("dot"));
-                if (!map.hasImage("dot")) {
-                    const compass = this.$loadAsset("Icon_Map_Dot.png");
-                    map.loadImage(compass, (error, image) => {
-                        console.log("loaded", image);
-                        console.log("loaded e", error);
-                        if (error) reject(error);
-                        if (!map.hasImage("dot")) {
-                            console.log("adding img");
-                            map.addImage("dot", image);
-                            resolve();
-                        }
-                    });
-                }
-                resolve();
-            });
+            }
+
+            setTimeout(() => {
+                map.resize();
+
+                this.ready = true;
+                this.updateMap();
+
+                // Force model to update.
+                this.newBounds();
+            }, 100);
         },
         newBounds() {
             const map = this.protectedData.map;

--- a/portal/src/views/shared/StationsMap.vue
+++ b/portal/src/views/shared/StationsMap.vue
@@ -101,23 +101,42 @@ export default Vue.extend({
             console.log("map: loaded");
             this.protectedData.map = map;
 
-            if (!map.hasImage("dot")) {
-                const compass = this.$loadAsset("Icon_Map_Dot.png");
-                map.loadImage(compass, (error, image) => {
-                    if (error) throw error;
-                    if (!map.hasImage("dot")) {
-                        map.addImage("dot", image);
-                    }
+            this.loadCompassImage(map)
+                .then(() => {
+                    setTimeout(() => {
+                        console.log("ressize");
+                        map.resize();
+
+                        this.ready = true;
+                        this.updateMap();
+
+                        // Force model to update.
+                        this.newBounds();
+                    }, 100);
+                })
+                .catch((error) => {
+                    throw error;
                 });
-            }
-
-            map.resize();
-
-            this.ready = true;
-            this.updateMap();
-
-            // Force model to update.
-            this.newBounds();
+        },
+        loadCompassImage(map) {
+            // return new Promise((resolve => resolve()));
+            return new Promise((resolve, reject) => {
+                console.log('map.hasImage("dot")', map.hasImage("dot"));
+                if (!map.hasImage("dot")) {
+                    const compass = this.$loadAsset("Icon_Map_Dot.png");
+                    map.loadImage(compass, (error, image) => {
+                        console.log("loaded", image);
+                        console.log("loaded e", error);
+                        if (error) reject(error);
+                        if (!map.hasImage("dot")) {
+                            console.log("adding img");
+                            map.addImage("dot", image);
+                            resolve();
+                        }
+                    });
+                }
+                resolve();
+            });
         },
         newBounds() {
             const map = this.protectedData.map;


### PR DESCRIPTION
I am not proud of this fix but it looks like there is no other way with to overcome the issue with the current mapbox gl codebase.

Basically the issue is that the map is updating (specifically map.addLayer) before the icon is fully loaded. If you add some console logs you will see that the update happens before the loadImage callback is called. However, only sometimes it does throw the error "Image "dot" could not be loaded. Please make sure you have added the image with map.addImage() or a "sprite" property in your style. You can provide missing images by listening for the "styleimagemissing" map event."

I've tried to wrap the loadImage functionality in a promise but it has no effect since they did not write an async function for it. There is no way to wait for it to finish, except the setTimeout with 100ms.

Another solution would be to listen for the styleimagemissing event and trigger all the flow again, but I think this is worse than using a timeout since all the functions will be called 2 times.

You can find more info about the issue here https://github.com/mapbox/mapbox-gl-js/issues/9018 , unfortunately it's still an open issue.

Let me know what you think.