### PR TITLE
fix: markers without a latestPrimary reading value should default to …

### DIFF
--- a/portal/src/views/shared/ValueMarker.vue
+++ b/portal/src/views/shared/ValueMarker.vue
@@ -25,6 +25,11 @@ export default Vue.extend({
             type: Number
         }
     },
+    mounted () {
+        if(this.value === undefined){
+            this.color = "#ccc";
+        }
+    },
     methods: {
         onClick () {
             this.$emit("marker-click", { id: this.id });


### PR DESCRIPTION
Small change to fix markers that don't have a latest reading available to be displayed as gray