### PR TITLE
fix: set vue-confirm-dialog to last working version

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -44,7 +44,7 @@
         "vue-audio": "^0.0.12",
         "vue-body-class": "^3.0.2",
         "vue-class-component": "^7.2.3",
-        "vue-confirm-dialog": "^1.0.2",
+        "vue-confirm-dialog": "1.0.2",
         "vue-i18n": "^8.17.0",
         "vue-mention": "^1.0.0",
         "vue-meta": "^2.4.0",


### PR DESCRIPTION
Vue confirm dialog plugin was broken by their maintainer. For now the solution is to use a previous version, so I set it in package.json

https://github.com/aslanon/vue-confirm-dialog/issues/56