### PR TITLE
fix: key box alignment fix for floodnet css

### DIFF
--- a/portal/src/views/viz/ExploreWorkspace.vue
+++ b/portal/src/views/viz/ExploreWorkspace.vue
@@ -461,6 +461,10 @@ export default Vue.extend({
     margin-right: 15px;
     line-height: 35px;
     font-size: 40px;
+
+    body.floodnet & {
+        margin-top: -10px;
+    }
 }
 
 .controls-container .right {


### PR DESCRIPTION
Small change to fix the alignment of the key box under the floodnet css