### PR TITLE
fix: remove module root label from tree-select; pull label from "stri…

### DIFF
--- a/portal/src/views/viz/ViewingControls.ts
+++ b/portal/src/views/viz/ViewingControls.ts
@@ -147,7 +147,7 @@ export const SelectionControls = Vue.extend({
                 return [];
             }
             const stationId = vizSensor[0]; // TODO VizSensor
-            const sensorOptions = this.workspace.sensorOptions(stationId);
+            const sensorOptions = this.workspace.sensorOptions(stationId, this.workspace.projects[0] === 174); //TODO floodnet hack
             // this.viz.log("sensor-options", { options: sensorOptions });
             return sensorOptions;
         },

--- a/portal/src/views/viz/viz.ts
+++ b/portal/src/views/viz/viz.ts
@@ -840,7 +840,7 @@ export class Workspace implements VizInfoFactory {
         });
     }
 
-    public sensorOptions(stationId: number): SensorTreeOption[] {
+    public sensorOptions(stationId: number, flatten = false): SensorTreeOption[] {
         const station = this.stations[stationId];
         if (!station) throw new Error("viz: No station");
         const allSensors = station.sensors;
@@ -863,7 +863,11 @@ export class Workspace implements VizInfoFactory {
                 const children: SensorTreeOption[] = _.flatten(
                     uniqueSensors.map((row) => {
                         const age = moment.utc(row.sensorReadAt);
-                        const label = i18n.tc(row.sensorKey) || row.sensorKey;
+                        let label = i18n.tc(row.sensorKey) || row.sensorKey;
+                        //TODO floodnet hack
+                        if(flatten) {
+                            label = moduleMeta.sensors.filter( d => d.fullKey === row.sensorKey )[0]['strings']['enUs']['label'];
+                        }
                         const optionId = `${row.moduleId}-${row.sensorId}`;
                         const sensor = moduleMeta.sensors.filter((s) => s.fullKey == row.sensorKey);
                         if (sensor.length) {
@@ -878,7 +882,13 @@ export class Workspace implements VizInfoFactory {
                 if (!moduleAge) throw new Error(`viz: Expected module age: no sensors?`);
 
                 const label = i18n.tc(moduleKey); //  + ` (${moduleAge.fromNow()})`;
-                return new SensorTreeOption(`${moduleKey}-${moduleId}`, label, children, moduleId, null, moduleAge);
+                
+                if (flatten){
+                    return children[0];
+                }
+                else {
+                    return new SensorTreeOption(`${moduleKey}-${moduleId}`, label, children, moduleId, null, moduleAge);
+                }
             }
         );
 


### PR DESCRIPTION
FK-4265 - Remove "FloodNet" sub header text in 2nd dropdown
FK-4235 - Data View: 2nd dropdown - Update "Depth" label to "Flood Depth"

The dropdown wasn't actually pointing to the "strings" json for the label but creating it out of the sensorKey. The label in strings was correct so I just pointed to it without adding the separate labels as discussed.