### PR TITLE
fix: wait for sidebar animation to finish before map resize

### DIFF
--- a/portal/src/views/projects/ProjectBigMap.vue
+++ b/portal/src/views/projects/ProjectBigMap.vue
@@ -1,5 +1,5 @@
 <template>
-    <StandardLayout @sidebar-toggle="layoutChanges++" :sidebarNarrow="true" :clipStations="true">
+    <StandardLayout @sidebar-toggle="sidebarToggle()" :sidebarNarrow="true" :clipStations="true">
         <div class="project-public project-container" v-if="displayProject">
             <div class="project-detail-card">
                 <div class="photo-container">
@@ -205,6 +205,11 @@ export default Vue.extend({
             } catch (error) {
                 return [];
             }
+        },
+        sidebarToggle() {
+            setTimeout(() => {
+                this.layoutChanges++;
+            }, 250);
         },
     },
 });


### PR DESCRIPTION
Fix map sizing on sidebar toggle by waiting for animation to finish before triggering a mapbox resize.