### PR TITLE
chore: bump required dep go version

### DIFF
--- a/README.org
+++ b/README.org
@@ -16,7 +16,7 @@
    In order to build this project and be able to run it yourself you'll need the following dependencies:
 
    - Docker (19.03.12) (https://docs.docker.com/get-docker/)
-   - Golang 1.15 (https://golang.org/dl/)
+   - Golang 1.17 (https://golang.org/dl/)
    - nodejs (12.18.1) (https://nodejs.org/en/download/)
    - yarn (1.22.4)
 


### PR DESCRIPTION
Looks like go needs to be updated:

<img width="591" alt="Screenshot 2022-06-21 at 16 07 55" src="https://user-images.githubusercontent.com/31142342/174806875-d8c3aae5-a00a-4b96-a49c-15a96e0a33f1.png">
