### PR TITLE
fix: reorder marks only; change secondary chart color

### DIFF
--- a/portal/src/views/viz/vega/TimeSeriesSpecFactory.ts
+++ b/portal/src/views/viz/vega/TimeSeriesSpecFactory.ts
@@ -8,7 +8,7 @@ export class TimeSeriesSpecFactory {
     constructor(private readonly allSeries, private readonly settings: ChartSettings = ChartSettings.Container) {}
 
     create() {
-        const mapSeries = (mapFn: MapFunction<unknown>) => this.allSeries.reverse().map(mapFn);
+        const mapSeries = (mapFn: MapFunction<unknown>) => this.allSeries.map(mapFn);
         const makeDataName = (i: number) => `table${i + 1}`;
         const makeValidDataName = (i: number) => `table${i + 1}Valid`;
         const makeBarDataName = (i: number) => `table${i + 1}Bar`;
@@ -783,7 +783,7 @@ export class TimeSeriesSpecFactory {
                         },
                     ];
                 }
-            })
+            }).reverse()
         );
 
         // TODO Unique by thresholds and perhaps y value?

--- a/portal/src/views/viz/vega/chartStyles.ts
+++ b/portal/src/views/viz/vega/chartStyles.ts
@@ -3,14 +3,14 @@ export default {
         stroke: "#003F5C",
     },
     secondaryLine: {
-        stroke: "#A05195",
+        stroke: "#6ef0da",
     },
     primaryBar: {
         stroke: "#003F5C",
         fill: "#003F5C",
     },
     secondaryBar: {
-        stroke: "#A05195",
-        fill: "#A05195",
+        stroke: "#6ef0da",
+        fill: "#6ef0da",
     },
 };


### PR DESCRIPTION
- Very small change to make the vega charts follow the stacking order of the dropdown*
- Change the secondary data color

* edit: found a better station to test this on locally and made a modification to where the reordering was happening