### PR TITLE
fix: change sort ordering to always put bar charts behind line charts

### DIFF
--- a/portal/src/views/viz/vega/TimeSeriesSpecFactory.ts
+++ b/portal/src/views/viz/vega/TimeSeriesSpecFactory.ts
@@ -785,6 +785,16 @@ export class TimeSeriesSpecFactory {
                 }
             }).reverse()
         );
+        
+        // define mark stacking priority
+        const getMarkSortIndex = (d) =>  {
+            if(d['marks']) {
+                if (d['marks'][0].type === "line") return 1;
+                if (d['marks'][0].type === "rect") return 2;
+                else return 0;
+            }
+            else return 0;
+        };
 
         // TODO Unique by thresholds and perhaps y value?
         const ruleMarks = _.flatten(
@@ -864,7 +874,13 @@ export class TimeSeriesSpecFactory {
             ];
         };
 
-        const marks = [...cellMarks(), ...brushMarks, ...ruleMarks, ...seriesMarks];
+        console.log(seriesMarks.sort((a,b) => {
+            return getMarkSortIndex(a) - getMarkSortIndex(b);
+        }))
+
+        const marks = [...cellMarks(), ...brushMarks, ...ruleMarks, ...seriesMarks.sort((a,b) => {
+            return getMarkSortIndex(b) - getMarkSortIndex(a);
+        })];
 
         const interactiveSignals = [
             {


### PR DESCRIPTION
Modified to always put line charts in front of bar charts instead of by the order of addition