### PR TITLE
Fix/fk 4304 label templating

### DIFF
--- a/portal/src/views/projects/ProjectBigMap.vue
+++ b/portal/src/views/projects/ProjectBigMap.vue
@@ -41,7 +41,7 @@
                             <h4>Current {{ keyTitle }}</h4>
                             <div class="legend-item" v-for="(item, idx) in levels" :key="idx">
                                 <span class="legend-dot" :style="{ color: item.color }">&#x25CF;</span>
-                                <span>{{ item.label["enUS"] }}</span>
+                                <span>{{ fnKeyLabels[idx] }}</span>
                             </div>
                             <div class="legend-item" v-if="hasStationsWithoutData">
                                 <span class="legend-dot" style="color: #ccc">&#x25CF;</span>
@@ -118,6 +118,7 @@ export default Vue.extend({
         viewType: string;
         recentMapMode: boolean;
         legendCollapsed: boolean;
+        fnKeyLabels: string [];
     } {
         return {
             layoutChanges: 0,
@@ -125,6 +126,7 @@ export default Vue.extend({
             viewType: "map",
             recentMapMode: false,
             legendCollapsed: false,
+            fnKeyLabels: ["None or Minimal", "Minor (4\"-12\")", "Moderate (12\"-24\")", "Major (> 24\")"]
         };
     },
     props: {


### PR DESCRIPTION
More FN label change requests. Since the map key is currently only visible to the FN project and it's unlikely for a typical project to have differing key labels for the map and charts these label changes have been added to the component instead of a db change.